### PR TITLE
Remove func reference after once is invoked

### DIFF
--- a/projects/micro-dash/src/lib/function/once.ts
+++ b/projects/micro-dash/src/lib/function/once.ts
@@ -3,7 +3,7 @@
  *
  * Contribution to minified bundle size, when it is the only function imported:
  * - Lodash: 1,421 bytes
- * - Micro-dash: 60 bytes
+ * - Micro-dash: 67 bytes
  */
 export function once<T extends Function>(func: T): T {
   let result: any;

--- a/projects/micro-dash/src/lib/function/once.ts
+++ b/projects/micro-dash/src/lib/function/once.ts
@@ -12,6 +12,7 @@ export function once<T extends Function>(func: T): T {
     if (needsCall) {
       needsCall = false;
       result = func.apply(this, arguments);
+      (func as any) = null;
     }
     return result;
   } as any) as T;


### PR DESCRIPTION
Hi. Really like what you're doing with this project.

In my mind, an important characteristic of the `once` function is that it forgets the function it wraps after it doesn't need it anymore. This doesn't produce any behavioural change, but the garbage collector doesn't know that `func` isn't needed anymore (or if it did figure that out via static analysis I would be extremely impressed).

Lodash can be seen doing this here:
https://github.com/lodash/lodash/blob/master/before.js#L26

Holding onto `func` is potentially quite bad as functions can easily prevent arbitrarily large amounts of memory from being garbage collected by holding references via closure.

By the way, if you don't like the way I'm circumventing the type system here I'd be happy to switch to a type safe version, but I think it would introduce a few unnecessary bytes :stuck_out_tongue:.