### PR TITLE
Feature request: better typing for `get()`

### DIFF
--- a/projects/micro-dash/src/lib/object/get.spec.ts
+++ b/projects/micro-dash/src/lib/object/get.spec.ts
@@ -81,4 +81,11 @@ describe("get()", () => {
   it("should return the default value when `path` is empty", () => {
     expect(get({}, [], "a")).toBe("a");
   });
+
+  it("should know that `get` cannot return `undefined` when a default value is given", () => {
+    const obj: { value?: number } = {};
+    const notUndefined = get(obj, ["value"], 1);
+
+    notUndefined.toString(); // does not give a typescript error
+  });
 });

--- a/projects/micro-dash/src/lib/object/get.spec.ts
+++ b/projects/micro-dash/src/lib/object/get.spec.ts
@@ -1,6 +1,14 @@
 import { get } from "./get";
 
 describe("get()", () => {
+  it("should know that `get` cannot return `undefined` when a default value is given", () => {
+    let result: number;
+    result = get(new Wrap1(), ["value"], 1);
+    result = get(new Wrap2(), ["wrap1", "value"], 1);
+    result = get(new Wrap3(), ["wrap2", "wrap1", "value"], 1);
+    result = get(new Wrap4(), ["wrap3", "wrap2", "wrap1", "value"], 1);
+  });
+
   //
   // stolen from https://github.com/lodash/lodash
   //
@@ -14,7 +22,8 @@ describe("get()", () => {
   });
 
   it("should handle empty paths", () => {
-    expect(get({}, [])).toBeUndefined();
+    const result: undefined = get({}, []);
+    expect(result).toBeUndefined();
     expect(get({ "": 3 }, [""])).toBe(3);
   });
 
@@ -81,11 +90,20 @@ describe("get()", () => {
   it("should return the default value when `path` is empty", () => {
     expect(get({}, [], "a")).toBe("a");
   });
-
-  it("should know that `get` cannot return `undefined` when a default value is given", () => {
-    const obj: { value?: number } = {};
-    const notUndefined = get(obj, ["value"], 1);
-
-    notUndefined.toString(); // does not give a typescript error
-  });
 });
+
+class Wrap1 {
+  value?: number;
+}
+
+class Wrap2 {
+  wrap1 = new Wrap1();
+}
+
+class Wrap3 {
+  wrap2 = new Wrap2();
+}
+
+class Wrap4 {
+  wrap3 = new Wrap3();
+}

--- a/projects/micro-dash/src/lib/object/get.ts
+++ b/projects/micro-dash/src/lib/object/get.ts
@@ -16,6 +16,36 @@ export function get<T, K1 extends keyof T, R extends T[K1]>(
   path: [K1],
   defaultValue: R,
 ): R extends undefined ? T[K1] : Exclude<T[K1], undefined>;
+export function get<T, K1 extends keyof T, K2 extends keyof T[K1], R>(
+  object: T,
+  path: [K1, K2],
+  defaultValue: T[K1][K2],
+): R extends undefined ? T[K1][K2] : Exclude<T[K1][K2], undefined>;
+export function get<
+  T,
+  K1 extends keyof T,
+  K2 extends keyof T[K1],
+  K3 extends keyof T[K1][K2],
+  R
+>(
+  object: T,
+  path: [K1, K2, K3],
+  defaultValue: T[K1][K2][K3],
+): R extends undefined ? T[K1][K2][K3] : Exclude<T[K1][K2][K3], undefined>;
+export function get<
+  T,
+  K1 extends keyof T,
+  K2 extends keyof T[K1],
+  K3 extends keyof T[K1][K2],
+  K4 extends keyof T[K1][K2][K3],
+  R
+>(
+  object: T,
+  path: [K1, K2, K3, K4],
+  defaultValue: T[K1][K2][K3][K4],
+): R extends undefined
+  ? T[K1][K2][K3][K4]
+  : Exclude<T[K1][K2][K3][K4], undefined>;
 export function get<T, K1 extends keyof T>(
   object: T,
   path: [K1],

--- a/projects/micro-dash/src/lib/object/get.ts
+++ b/projects/micro-dash/src/lib/object/get.ts
@@ -11,11 +11,11 @@ import { Nil } from "../interfaces";
  * - Micro-dash: 65 bytes
  */
 
-export function get<T, K1 extends keyof T, R>(
+export function get<T, K1 extends keyof T, R extends T[K1]>(
   object: T,
   path: [K1],
   defaultValue: R,
-): R;
+): R extends undefined ? T[K1] : Exclude<T[K1], undefined>;
 export function get<T, K1 extends keyof T>(
   object: T,
   path: [K1],

--- a/projects/micro-dash/src/lib/object/get.ts
+++ b/projects/micro-dash/src/lib/object/get.ts
@@ -11,39 +11,39 @@ import { Nil } from "../interfaces";
  * - Micro-dash: 65 bytes
  */
 
-export function get<T, K1 extends keyof T, R extends T[K1]>(
+export function get<T, K1 extends keyof T, D extends T[K1]>(
   object: T,
   path: [K1],
-  defaultValue: R,
-): R extends undefined ? T[K1] : Exclude<T[K1], undefined>;
-export function get<T, K1 extends keyof T, K2 extends keyof T[K1], R>(
+  defaultValue: D,
+): D extends undefined ? T[K1] : Exclude<T[K1], undefined>;
+export function get<T, K1 extends keyof T, K2 extends keyof T[K1], D>(
   object: T,
   path: [K1, K2],
   defaultValue: T[K1][K2],
-): R extends undefined ? T[K1][K2] : Exclude<T[K1][K2], undefined>;
+): D extends undefined ? T[K1][K2] : Exclude<T[K1][K2], undefined>;
 export function get<
   T,
   K1 extends keyof T,
   K2 extends keyof T[K1],
   K3 extends keyof T[K1][K2],
-  R
+  D
 >(
   object: T,
   path: [K1, K2, K3],
   defaultValue: T[K1][K2][K3],
-): R extends undefined ? T[K1][K2][K3] : Exclude<T[K1][K2][K3], undefined>;
+): D extends undefined ? T[K1][K2][K3] : Exclude<T[K1][K2][K3], undefined>;
 export function get<
   T,
   K1 extends keyof T,
   K2 extends keyof T[K1],
   K3 extends keyof T[K1][K2],
   K4 extends keyof T[K1][K2][K3],
-  R
+  D
 >(
   object: T,
   path: [K1, K2, K3, K4],
   defaultValue: T[K1][K2][K3][K4],
-): R extends undefined
+): D extends undefined
   ? T[K1][K2][K3][K4]
   : Exclude<T[K1][K2][K3][K4], undefined>;
 export function get<T, K1 extends keyof T>(

--- a/projects/micro-dash/src/lib/object/get.ts
+++ b/projects/micro-dash/src/lib/object/get.ts
@@ -11,26 +11,32 @@ import { Nil } from "../interfaces";
  * - Micro-dash: 65 bytes
  */
 
+export function get<D>(object: object, path: [], defaultValue?: D): D;
 export function get<T, K1 extends keyof T, D extends T[K1]>(
   object: T,
   path: [K1],
-  defaultValue: D,
+  defaultValue?: D,
 ): D extends undefined ? T[K1] : Exclude<T[K1], undefined>;
-export function get<T, K1 extends keyof T, K2 extends keyof T[K1], D>(
+export function get<
+  T,
+  K1 extends keyof T,
+  K2 extends keyof T[K1],
+  D extends T[K1][K2]
+>(
   object: T,
   path: [K1, K2],
-  defaultValue: T[K1][K2],
+  defaultValue?: D,
 ): D extends undefined ? T[K1][K2] : Exclude<T[K1][K2], undefined>;
 export function get<
   T,
   K1 extends keyof T,
   K2 extends keyof T[K1],
   K3 extends keyof T[K1][K2],
-  D
+  D extends T[K1][K2][K3],
 >(
   object: T,
   path: [K1, K2, K3],
-  defaultValue: T[K1][K2][K3],
+  defaultValue?: D,
 ): D extends undefined ? T[K1][K2][K3] : Exclude<T[K1][K2][K3], undefined>;
 export function get<
   T,
@@ -38,41 +44,14 @@ export function get<
   K2 extends keyof T[K1],
   K3 extends keyof T[K1][K2],
   K4 extends keyof T[K1][K2][K3],
-  D
+  D extends T[K1][K2][K3][K4],
 >(
   object: T,
   path: [K1, K2, K3, K4],
-  defaultValue: T[K1][K2][K3][K4],
+  defaultValue?: D,
 ): D extends undefined
   ? T[K1][K2][K3][K4]
   : Exclude<T[K1][K2][K3][K4], undefined>;
-export function get<T, K1 extends keyof T>(
-  object: T,
-  path: [K1],
-  defaultValue: T[K1],
-): T[K1];
-export function get<T, K1 extends keyof T, K2 extends keyof T[K1]>(
-  object: T,
-  path: [K1, K2],
-  defaultValue: T[K1][K2],
-): T[K1][K2];
-export function get<
-  T,
-  K1 extends keyof T,
-  K2 extends keyof T[K1],
-  K3 extends keyof T[K1][K2]
->(object: T, path: [K1, K2, K3], defaultValue: T[K1][K2][K3]): T[K1][K2][K3];
-export function get<
-  T,
-  K1 extends keyof T,
-  K2 extends keyof T[K1],
-  K3 extends keyof T[K1][K2],
-  K4 extends keyof T[K1][K2][K3]
->(
-  object: T,
-  path: [K1, K2, K3, K4],
-  defaultValue: T[K1][K2][K3][K4],
-): T[K1][K2][K3][K4];
 export function get(
   object: object | Nil,
   path: string[],

--- a/projects/micro-dash/src/lib/object/get.ts
+++ b/projects/micro-dash/src/lib/object/get.ts
@@ -11,6 +11,11 @@ import { Nil } from "../interfaces";
  * - Micro-dash: 65 bytes
  */
 
+export function get<T, K1 extends keyof T, R>(
+  object: T,
+  path: [K1],
+  defaultValue: R,
+): R;
 export function get<T, K1 extends keyof T>(
   object: T,
   path: [K1],


### PR DESCRIPTION
I would like typescript to know that `get()` cannot return `undefined` in a case like this:

```ts
const obj: { value?: number } = {};
const notUndefined: number = get(obj, ['value'], 1);
```